### PR TITLE
Grand stability upgrade #3 (#323)

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
@@ -47,4 +47,8 @@ public interface PokemapAppPreferences {
     Set<PokemonIdOuterClass.PokemonId> getShowablePokemonIDs();
 
     void setShowablePokemonIDs(Set<PokemonIdOuterClass.PokemonId> pokemonIDs);
+
+    void setShowMapSuggestion(boolean showMapSuggestion);
+
+    boolean getShowMapSuggestion();
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
@@ -39,6 +39,7 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
     private static final String SERVICE_REFRESH_KEY = "service_refresh_rate";
     private static final String POKEMONS_TO_SHOW = "pokemons_to_show";
     private static final String STEPS = "search_steps";
+    private static final String SHOW_MAP_SUGGESTION = "show_map_suggestion";
 
     private static final String INFO_TOKEN = "token=";
     private static final String INFO_REFRESH = "refresh=";
@@ -175,7 +176,7 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
 
     @Override
     public boolean getShowLuredPokemon() {
-        return sharedPreferences.getBoolean(SHOW_LURED, false);
+        return sharedPreferences.getBoolean(SHOW_LURED, true);
     }
 
     public Set<PokemonIdOuterClass.PokemonId> getShowablePokemonIDs() {
@@ -202,6 +203,16 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
             showablePokemonStringIDs.add(String.valueOf(pokemonId.getNumber()));
         }
         sharedPreferences.edit().putStringSet(POKEMONS_TO_SHOW, showablePokemonStringIDs).apply();
+    }
+
+    @Override
+    public void setShowMapSuggestion(boolean showMapSuggestion) {
+        sharedPreferences.edit().putBoolean(SHOW_MAP_SUGGESTION, showMapSuggestion).apply();
+    }
+
+    @Override
+    public boolean getShowMapSuggestion() {
+        return sharedPreferences.getBoolean(SHOW_MAP_SUGGESTION, true);
     }
 
     @Override

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
@@ -184,7 +184,7 @@ public class NianticManager {
             @Override
             public void onResponse(Call<NianticService.LoginResponse> call, Response<NianticService.LoginResponse> response) {
                 String location = response.headers().get("location");
-                if (location != null) {
+                if (location != null && location.split("ticket=").length > 0) {
                     String ticket = location.split("ticket=")[1];
                     requestToken(ticket, loginListener);
                 } else {

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
@@ -39,6 +39,8 @@ public class PokemonNotificationService extends Service{
     private static final int notificationId = 2423235;
     private static final String ACTION_STOP_SELF = "com.omkarmoghe.pokemap.STOP_SERVICE";
 
+    public static boolean isRunning = false;
+
     private UpdateRunnable updateRunnable;
     private Thread workThread;
     private LocationManager locationManager;
@@ -66,13 +68,14 @@ public class PokemonNotificationService extends Service{
         locationManager = LocationManager.getInstance(this);
         nianticManager = NianticManager.getInstance();
 
-        updateRunnable = new UpdateRunnable(preffs.getServiceRefreshRate());
+        updateRunnable = new UpdateRunnable(preffs.getServiceRefreshRate() * 1000);
         workThread = new Thread(updateRunnable);
 
         initBroadcastReciever();
         workThread.start();
         locationManager.onResume();
 
+        isRunning = true;
     }
 
     /**
@@ -90,6 +93,7 @@ public class PokemonNotificationService extends Service{
         updateRunnable.stop();
         EventBus.getDefault().unregister(this);
         unregisterReceiver(mBroadcastReciever);
+        isRunning = false;
     }
 
     @Override
@@ -175,22 +179,30 @@ public class PokemonNotificationService extends Service{
 
         @Override
         public void run() {
-            while(isRunning){
-                try{
-                    LatLng currentLocation = locationManager.getLocation();
 
-                    if(currentLocation != null){
-                        nianticManager.getCatchablePokemon(currentLocation.latitude,currentLocation.longitude,0);
-                    }else {
-                        locationManager = LocationManager.getInstance(PokemonNotificationService.this);
-                    }
+                try {
+
+                    // initial wait (fFor a reason! Do NOT remove because of cyclic sleep!)
                     Thread.sleep(refreshRate);
 
+                    while (isRunning) {
+
+                        LatLng currentLocation = locationManager.getLocation();
+
+                        if (currentLocation != null){
+                            nianticManager.getCatchablePokemon(currentLocation.latitude,currentLocation.longitude,0);
+                        } else {
+                            locationManager = LocationManager.getInstance(PokemonNotificationService.this);
+                        }
+
+                        // cyclic sleep
+                        Thread.sleep(refreshRate);
+
+                    }
                 } catch (InterruptedException | NullPointerException e) {
                     e.printStackTrace();
                     Log.e(TAG, "Failed updating. UpdateRunnable.run() raised: " + e.getMessage());
                 }
-            }
         }
 
         public void stop(){
@@ -205,4 +217,8 @@ public class PokemonNotificationService extends Service{
             locationManager.onPause();
         }
     };
+
+    public static boolean isRunning() {
+        return isRunning;
+    }
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
@@ -170,6 +170,12 @@ public class MainActivity extends BaseActivity {
     }
 
     private void startNotificationService(){
+
+        // check for if the service is already running
+        if (PokemonNotificationService.isRunning()) {
+            stopNotificationService();
+        }
+
         Intent intent = new Intent(this, PokemonNotificationService.class);
         startService(intent);
     }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -94,9 +94,8 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     private View mView;
     private SupportMapFragment mSupportMapFragment;
     private GoogleMap mGoogleMap;
-    private Location mLocation = null;
+    private static Location mLocation = null;
     private PokemonMarkerExtended mSelectedMarker;
-    private Location currentCenter = new Location("0,0");
     private Map<String, GymMarkerExtended> gymsList = new HashMap<>();
     Map<Integer, String> gymTeamImageUrls = new HashMap<>();
     String lurePokeStopImageUrl = "http://i.imgur.com/2BI3Cqv.png";
@@ -161,7 +160,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
             public void onLocationChanged(Location location) {
                 if (mLocation == null) {
                     mLocation = location;
-                    initMap();
+                    initMap(true, true);
                 } else {
                     mLocation = location;
                 }
@@ -195,7 +194,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
             @Override
             public void onClick(View view) {
                 if (mLocation != null && mGoogleMap != null) {
-                    mGoogleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
+                    mGoogleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(
                             new LatLng(mLocation.getLatitude(), mLocation.getLongitude()), 15));
                 } else {
                     showLocationFetchFailed();
@@ -206,40 +205,69 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         mView.findViewById(R.id.closeSuggestions).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mView.findViewById(R.id.layoutSuggestions).setVisibility(View.GONE);
+
+                hideMapSuggestion();
             }
         });
+
+        if (!mPref.getShowMapSuggestion()) {
+            hideMapSuggestion();
+        }
 
         return mView;
     }
 
-    private void initMap() {
-        pokeSnackbar = Snackbar.make(getView(), "", Snackbar.LENGTH_LONG);
-        if (mLocation != null && mGoogleMap != null) {
-            if (ContextCompat.checkSelfPermission(mView.getContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
-                    || ContextCompat.checkSelfPermission(mView.getContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+    private void hideMapSuggestion() {
 
-                new AlertDialog.Builder(getActivity())
-                        .setTitle(getString(R.string.enable_location_permission_title))
-                        .setMessage(getString(R.string.enable_location_permission_message))
-                        .setPositiveButton(getString(R.string.button_ok), null)
-                        .show();
-                return;
-            }
-            mGoogleMap.setMyLocationEnabled(true);
+        mPref.setShowMapSuggestion(false);
 
-            LatLng currentLatLngLocation = new LatLng(mLocation.getLatitude(), mLocation.getLongitude());
-            mGoogleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
-                    currentLatLngLocation, 15));
-
-            //Run the initial scan at the current location reusing the long click function
-            SearchInPosition sip = new SearchInPosition();
-            sip.setPosition(currentLatLngLocation);
-            sip.setSteps(1);
-            EventBus.getDefault().post(sip);
-        } else {
-            showLocationFetchFailed();
+        if (mView != null) {
+            mView.findViewById(R.id.layoutSuggestions).setVisibility(View.GONE);
         }
+    }
+
+    private void initMap(boolean animateZoomIn, boolean searchInPlace) {
+
+        if (getView() != null) {
+            pokeSnackbar = Snackbar.make(getView(), "", Snackbar.LENGTH_LONG);
+            if (mLocation != null && mGoogleMap != null) {
+                if (ContextCompat.checkSelfPermission(mView.getContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED
+                        || ContextCompat.checkSelfPermission(mView.getContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+
+                    new AlertDialog.Builder(getActivity())
+                            .setTitle(getString(R.string.enable_location_permission_title))
+                            .setMessage(getString(R.string.enable_location_permission_message))
+                            .setPositiveButton(getString(R.string.button_ok), null)
+                            .show();
+                    return;
+                }
+                mGoogleMap.setMyLocationEnabled(true);
+
+                LatLng currentLatLngLocation = new LatLng(mLocation.getLatitude(), mLocation.getLongitude());
+
+                if (animateZoomIn) {
+                    mGoogleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(currentLatLngLocation, 15));
+                } else {
+                    mGoogleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(currentLatLngLocation, 15));
+                }
+
+                if (searchInPlace) {
+                    searchInPlace(currentLatLngLocation);
+                }
+
+            } else {
+                showLocationFetchFailed();
+            }
+        }
+    }
+
+    private void searchInPlace(LatLng latLngLocation) {
+
+        //Run the initial scan at the current location reusing the long click function
+        SearchInPosition sip = new SearchInPosition();
+        sip.setPosition(latLngLocation);
+        sip.setSteps(mPref.getSteps());
+        EventBus.getDefault().post(sip);
     }
 
     private void clearMarkers() {
@@ -722,6 +750,8 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         mGoogleMap.setOnMarkerClickListener(this);
         //Disable for now coz is under FAB
         settings.setMapToolbarEnabled(false);
+
+        initMap(false, false);
     }
 
     @Override

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/settings/SettingsActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/settings/SettingsActivity.java
@@ -42,10 +42,4 @@ public class SettingsActivity extends AppCompatActivity {
             recreate();
         }
     }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        NavUtils.navigateUpFromSameTask(this);
-    }
 }


### PR DESCRIPTION
* Prevent multiple NotificationService instances

* Added null check for getView() prevents crash
Amount of steps to search read from prefs
Zoom in map animation only for first time

* Prevent  java.lang.ArrayIndexOutOfBoundsException

* Removed unnecessary call; there is an Activity in the back

* Sleep timer calculated properly now (missed * 1000) so actually did only wait milliseconds. Uff.
Added initial sleep timer to prevent UpdateRunnable calling getCatchablePokemon() directly after invoke (get shortly invoked and shuts down then when resuming from Settings for example) -- using this initial sleep and proper calculated timing we might fix the EventBus issues as well.

* - Map suggestion remembers that it was closed. So it doesn't show up again after restart.
- After returning from SettingsActivity the map does not zoom like crazy. It just returns to the last known location (that why its static now)
- Initial search after login still zooms in. Now the initial search uses the  step range configured in the settings!